### PR TITLE
01_gateways: fix the order for TAGS in the document grammar

### DIFF
--- a/01_gateways.sdoc
+++ b/01_gateways.sdoc
@@ -14,9 +14,6 @@ ELEMENTS:
   - TITLE: STATUS
     TYPE: String
     REQUIRED: False
-  - TITLE: TAGS
-    TYPE: String
-    REQUIRED: False
   - TITLE: REFS
     TYPE: String
     REQUIRED: False
@@ -24,6 +21,9 @@ ELEMENTS:
     TYPE: String
     REQUIRED: False
   - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TAGS
     TYPE: String
     REQUIRED: False
   - TITLE: RATIONALE


### PR DESCRIPTION
@BenGardiner just FYI:

The validation of custom grammars has been improved in StrictDoc and it is now more sensitive to the order of the fields as they are declared in a custom grammar:

This document always has its TAGS: declared after STATEMENT: and the new (alpha) version of StrictDoc triggers a validation message.

Please merge this with a new release of StrictDoc.