### PR TITLE
References to HSM and challenge-response protocol

### DIFF
--- a/01_gateways.sdoc
+++ b/01_gateways.sdoc
@@ -145,6 +145,12 @@ TODO
 <<<
 CRITICALITY: High
 
+COMMENT: >>>
+This can be achieved by use of a Hardware Security Module (HSM) containing keys for verifying a configuration
+using a secure message authentication code (MAC) and where the HSM has a secure mechanism for remotely programming
+the MAC key. The SHE+ HSM (https://www.autosar.org/fileadmin/user_upload/standards/foundation/19-11/AUTOSAR_TR_SecureHardwareExtensions.pdf) is an example of such an HSM.
+<<<
+
 [REQUIREMENT]
 UID: AGW-S-001
 TITLE: Prevents OTA
@@ -269,8 +275,16 @@ The device SHALL have a means to temporarily disable the preventions listed prev
   * Example: Consent on Instrument cluster or infotainment device (and thus internal networks - possibly but not necessarily *TND*)
 
   * Example: Consent from third party device / application that is signed with infrastructure OEM has access to verify
-
 <<<
+
+COMMENT: >>>
+A Virtual Mode Switch can be achieved by use of a Hardware Security Module (HSM) that can verify a Message Authentication Code (MAC) of
+a mode change message, and where the key used for verifying the MAC can be programmed securely via remote commands.
+The SHE+ HSM (https://www.autosar.org/fileadmin/user_upload/standards/foundation/19-11/AUTOSAR_TR_SecureHardwareExtensions.pdf) is an example of such an HSM.
+Replay attacks are prevented by using a challenge-response protocol between the gateway and the remote device to
+exchange a sequence number or timestamp, for example the SKID3 protocol (ISO 9798-4, Chapter 5.2.2).
+<<<
+
 TAGS: CONTAINS_OPTIONS
 PUB_REFS: >>>
 TODO

--- a/01_gateways.sdoc
+++ b/01_gateways.sdoc
@@ -140,16 +140,15 @@ The following requirements must be satisfied by any device intended to be a gate
 UID: AGW-S-000
 TITLE: Gateway Configuration Protected
 STATEMENT: The device SHALL accept and react only to configuration changes which are correctly authorized and authenticated, regardless of origin of network domain.
-PUB_REFS: >>>
-TODO
-<<<
-CRITICALITY: High
-
 COMMENT: >>>
 This can be achieved by use of a Hardware Security Module (HSM) containing keys for verifying a configuration
 using a secure message authentication code (MAC) and where the HSM has a secure mechanism for remotely programming
-the MAC key. The SHE+ HSM (https://www.autosar.org/fileadmin/user_upload/standards/foundation/19-11/AUTOSAR_TR_SecureHardwareExtensions.pdf) is an example of such an HSM.
+the MAC key.
 <<<
+PUB_REFS: >>>
+https://www.autosar.org/fileadmin/user_upload/standards/foundation/19-11/AUTOSAR_TR_SecureHardwareExtensions.pdf for an example of a suitable HSM (the SHE+ HSM).
+<<<
+CRITICALITY: High
 
 [REQUIREMENT]
 UID: AGW-S-001
@@ -276,18 +275,16 @@ The device SHALL have a means to temporarily disable the preventions listed prev
 
   * Example: Consent from third party device / application that is signed with infrastructure OEM has access to verify
 <<<
-
+TAGS: CONTAINS_OPTIONS
 COMMENT: >>>
 A Virtual Mode Switch can be achieved by use of a Hardware Security Module (HSM) that can verify a Message Authentication Code (MAC) of
 a mode change message, and where the key used for verifying the MAC can be programmed securely via remote commands.
-The SHE+ HSM (https://www.autosar.org/fileadmin/user_upload/standards/foundation/19-11/AUTOSAR_TR_SecureHardwareExtensions.pdf) is an example of such an HSM.
+
 Replay attacks are prevented by using a challenge-response protocol between the gateway and the remote device to
 exchange a sequence number or timestamp, for example the SKID3 protocol (ISO 9798-4, Chapter 5.2.2).
 <<<
-
-TAGS: CONTAINS_OPTIONS
 PUB_REFS: >>>
-TODO
+https://www.autosar.org/fileadmin/user_upload/standards/foundation/19-11/AUTOSAR_TR_SecureHardwareExtensions.pdf for an example of a suitable HSM (the SHE+ HSM).
 <<<
 CRITICALITY: High
 


### PR DESCRIPTION
Added references to the SHE+ standard and a link to the AUTOSAR spec. Also added a reference to the three phase challenge response protocol specified in ISO 9798-4, for when a remote device like a touch screen sends a mode change command to the security gateway.

There are other ways to achieve this requirement, of course, but I think this is the most appropriate. The messaging does need protection against replay attacks, which can be done by the results of the cited authentication protocol.