### PR TITLE
Update to latest StrictDoc: Fragments are now child Documents

### DIFF
--- a/00_tsrm.sdoc
+++ b/00_tsrm.sdoc
@@ -2299,34 +2299,14 @@ VERIFICATION: >>>
 Inspection of vendor process documentation confirming participation in information sharing group.
 <<<
 
-[SECTION]
-TITLE: NMFTA Telematics (Cloud Component) Security Requirements
+[DOCUMENT_FROM_FILE]
+FILE: _cloud_tsrm.sdoc
 
-[FRAGMENT_FROM_FILE]
-FILE: cloud_tsrm.sinc
+[DOCUMENT_FROM_FILE]
+FILE: _connectivity_tsrm.sdoc
 
-[/SECTION]
+[DOCUMENT_FROM_FILE]
+FILE: _vehicle_connection_tsrm.sdoc
 
-[SECTION]
-TITLE: NMFTA Telematics (Connectivity or Communications Component) Security Requirements
-
-[FRAGMENT_FROM_FILE]
-FILE: connectivity_tsrm.sinc
-
-[/SECTION]
-
-[SECTION]
-TITLE: NMFTA Telematics (Vehicle Connection Component) Security Requirements
-
-[FRAGMENT_FROM_FILE]
-FILE: vehicle_connection_tsrm.sinc
-
-[/SECTION]
-
-[SECTION]
-TITLE: NMFTA Telematics (Mobile App Component) Security Requirements
-
-[FRAGMENT_FROM_FILE]
-FILE: mobile_app_tsrm.sinc
-
-[/SECTION]
+[DOCUMENT_FROM_FILE]
+FILE: _mobile_app_tsrm.sdoc

--- a/_cloud_tsrm.sdoc
+++ b/_cloud_tsrm.sdoc
@@ -1,4 +1,5 @@
-[FRAGMENT]
+[DOCUMENT]
+TITLE: NMFTA Telematics (Cloud Component) Security Requirements
 
 [REQUIREMENT]
 UID: CLOUD-AA-010

--- a/_connectivity_tsrm.sdoc
+++ b/_connectivity_tsrm.sdoc
@@ -1,4 +1,5 @@
-[FRAGMENT]
+[DOCUMENT]
+TITLE: NMFTA Telematics (Connectivity or Communications Component) Security Requirements
 
 [REQUIREMENT]
 UID: COMMS-AC-010

--- a/_mobile_app_tsrm.sdoc
+++ b/_mobile_app_tsrm.sdoc
@@ -1,4 +1,5 @@
-[FRAGMENT]
+[DOCUMENT]
+TITLE: NMFTA Telematics (Mobile App Component) Security Requirements
 
 [REQUIREMENT]
 UID: MOBILE-AC-010

--- a/_vehicle_connection_tsrm.sdoc
+++ b/_vehicle_connection_tsrm.sdoc
@@ -1,4 +1,5 @@
-[FRAGMENT]
+[DOCUMENT]
+TITLE: NMFTA Telematics (Vehicle Connection Component) Security Requirements
 
 [REQUIREMENT]
 UID: VEH-AC-010


### PR DESCRIPTION
Hi again,

This is to notify you that StrictDoc is undergoing a migration from Fragments to Documents. This work is not released yet but since this repository is using the latest main branch, I would like to send you the update proactively (this PR).

For a number of reasons, the developers decided to implement the document composition using the `Document` itself and `DOCUMENT_FROM_FILE` without using entities like Fragment. The `FRAGMENT`/`FRAGMENT_FROM_FILE` tags are being removed from the grammar completely, simplifying the overall handling of this feature.

To try the new workflow, install StrictDoc directly from the main branch as follows:

```
pip install -U --pre git+https://github.com/strictdoc-project/strictdoc.git@main
```

Let us know if there is any early feedback regarding this change. We are planning to release this still in March or in the beginning of April latest.

----

This how the composite document looks like now:

<img width="1280" alt="Bildschirmfoto 2024-03-18 um 21 47 11" src="https://github.com/nmfta-repo/vcr-experiment/assets/452547/869405a6-90e4-4056-9093-687146db496a">

----

The attached image shows that we still have to handle a few UI/UX edge cases. Stay tuned, we will fix those very soon. (tracked here https://github.com/strictdoc-project/strictdoc/issues/1709).

<img width="691" alt="Bildschirmfoto 2024-03-18 um 21 33 59" src="https://github.com/nmfta-repo/vcr-experiment/assets/452547/533b3fa6-ca86-4e6c-a8b5-096b4d0b3798">
